### PR TITLE
Optimize dockerfile, and improve nexus starting steps

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-chown -R nexus:nexus /opt/sonatype
-chown -R nexus:nexus /nexus-data
-su-exec nexus /opt/sonatype/nexus/bin/nexus run


### PR DESCRIPTION
Hi,

Please consider the following improvements:
- Make user/group/uid/gid configurable with docker --build-arg
- Set uid/gid
- Use tini cmd instead of su-exec to run nexus
- Implement USER instruction to run nexus as non-root at the dockerfile level
- Remove run service script

For your information, I use this docker image with the sonotype-nexus helm package in my k8s cluster (https://github.com/helm/charts/tree/master/stable/sonatype-nexus).
I had to do that in order to be sure the uid/gid will never change and remove the change owner instruction in the run service script. Using that image, I can restart nexus under two minutes, and I minimize the interruption of service during the upgrade path.