### PR TITLE
faster selective chown

### DIFF
--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-find /opt/sonatype ! \( -user nexus -a -group nexus \) -exec chown nexus:nexus {} \;
-find /nexus-data   ! \( -user nexus -a -group nexus \) -exec chown nexus:nexus {} \;
+find /opt/sonatype ! \( -user nexus -and -group nexus \) -exec chown nexus:nexus {} \;
+find /nexus-data   ! \( -user nexus -and -group nexus \) -exec chown nexus:nexus {} \;
 su-exec nexus /opt/sonatype/nexus/bin/nexus run

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-chown -R nexus:nexus /opt/sonatype
-chown -R nexus:nexus /nexus-data
+find /opt/sonatype ! \( -user nexus -o -group nexus \) -exec chown nexus:nexus {} \;	
+find /nexus-data   ! \( -user nexus -o -group nexus \) -exec chown nexus:nexus {} \;	
 su-exec nexus /opt/sonatype/nexus/bin/nexus run

--- a/run
+++ b/run
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-find /opt/sonatype ! \( -user nexus -o -group nexus \) -exec chown nexus:nexus {} \;	
-find /nexus-data   ! \( -user nexus -o -group nexus \) -exec chown nexus:nexus {} \;	
+find /opt/sonatype ! \( -user nexus -a -group nexus \) -exec chown nexus:nexus {} \;
+find /nexus-data   ! \( -user nexus -a -group nexus \) -exec chown nexus:nexus {} \;
 su-exec nexus /opt/sonatype/nexus/bin/nexus run


### PR DESCRIPTION
on lage repos chown takes long time (15+ min on a 400gb repo); 
Usually the pod is started with the same volume that was used before, so doing chown on all files is redundant; 

This change will only change the owner on files that need that. 
Speed gains on the same repo are significant, to run the find and check all files takes 10s.