### PR TITLE
Add option to disable chown on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV NEXUS_HOME "${SONATYPE_DIR}/nexus"
 ENV NEXUS_DATA /nexus-data
 ENV NEXUS_CONTEXT ''
 ENV SONATYPE_WORK ${SONATYPE_DIR}/sonatype-work
+ENV NEXUS_DATA_CHOWN "true"
 
 # Install prerequisites
 RUN apk add --no-cache --update bash ca-certificates runit su-exec util-linux openjdk8-jre
@@ -27,10 +28,10 @@ RUN apk add --no-cache -t .build-deps wget gnupg openssl \
   && echo "===> Installing Nexus ${NEXUS_VERSION}..." \
   && wget -O nexus.tar.gz $NEXUS_TARBALL_URL; \
   wget -O nexus.tar.gz.asc $NEXUS_TARBALL_ASC_URL; \
-    export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY; \
-    gpg --batch --verify nexus.tar.gz.asc nexus.tar.gz; \
-    rm -r $GNUPGHOME nexus.tar.gz.asc; \
+  export GNUPGHOME="$(mktemp -d)"; \
+  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY; \
+  gpg --batch --verify nexus.tar.gz.asc nexus.tar.gz; \
+  rm -r $GNUPGHOME nexus.tar.gz.asc; \
   tar -xf nexus.tar.gz \
   && mkdir -p $SONATYPE_DIR \
   && mv nexus-$NEXUS_VERSION $NEXUS_HOME \
@@ -43,12 +44,12 @@ RUN apk add --no-cache -t .build-deps wget gnupg openssl \
 
 # Configure nexus
 RUN sed \
-    -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' \
-    -i ${NEXUS_HOME}/etc/nexus-default.properties \
+  -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' \
+  -i ${NEXUS_HOME}/etc/nexus-default.properties \
   && sed \
-    -e '/^-Xms/d' \
-    -e '/^-Xmx/d' \
-    -i ${NEXUS_HOME}/bin/nexus.vmoptions
+  -e '/^-Xms/d' \
+  -e '/^-Xmx/d' \
+  -i ${NEXUS_HOME}/bin/nexus.vmoptions
 
 RUN mkdir -p ${NEXUS_DATA}/etc ${NEXUS_DATA}/log ${NEXUS_DATA}/tmp ${SONATYPE_WORK} \
   && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN apk add --no-cache -t .build-deps wget gnupg openssl \
   && echo "===> Installing Nexus ${NEXUS_VERSION}..." \
   && wget -O nexus.tar.gz $NEXUS_TARBALL_URL; \
   wget -O nexus.tar.gz.asc $NEXUS_TARBALL_ASC_URL; \
-  export GNUPGHOME="$(mktemp -d)"; \
-  gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY; \
-  gpg --batch --verify nexus.tar.gz.asc nexus.tar.gz; \
-  rm -r $GNUPGHOME nexus.tar.gz.asc; \
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $GPG_KEY; \
+    gpg --batch --verify nexus.tar.gz.asc nexus.tar.gz; \
+    rm -r $GNUPGHOME nexus.tar.gz.asc; \
   tar -xf nexus.tar.gz \
   && mkdir -p $SONATYPE_DIR \
   && mv nexus-$NEXUS_VERSION $NEXUS_HOME \
@@ -44,12 +44,12 @@ RUN apk add --no-cache -t .build-deps wget gnupg openssl \
 
 # Configure nexus
 RUN sed \
-  -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' \
-  -i ${NEXUS_HOME}/etc/nexus-default.properties \
+    -e '/^nexus-context/ s:$:${NEXUS_CONTEXT}:' \
+    -i ${NEXUS_HOME}/etc/nexus-default.properties \
   && sed \
-  -e '/^-Xms/d' \
-  -e '/^-Xmx/d' \
-  -i ${NEXUS_HOME}/bin/nexus.vmoptions
+    -e '/^-Xms/d' \
+    -e '/^-Xmx/d' \
+    -i ${NEXUS_HOME}/bin/nexus.vmoptions
 
 RUN mkdir -p ${NEXUS_DATA}/etc ${NEXUS_DATA}/log ${NEXUS_DATA}/tmp ${SONATYPE_WORK} \
   && ln -s ${NEXUS_DATA} ${SONATYPE_WORK}/nexus3 \

--- a/run
+++ b/run
@@ -1,5 +1,8 @@
 #!/bin/sh
 
-find /opt/sonatype ! \( -user nexus -and -group nexus \) -exec chown nexus:nexus {} \;
-find /nexus-data   ! \( -user nexus -and -group nexus \) -exec chown nexus:nexus {} \;
+if [ "$NEXUS_DATA_CHOWN" == "true" ]; then
+    chown -R nexus:nexus /opt/sonatype
+    chown -R nexus:nexus /nexus-data
+fi
+
 su-exec nexus /opt/sonatype/nexus/bin/nexus run


### PR DESCRIPTION
Fix for issue #32

Adds a flag to disable chown on nexus start. 

Should be disabled only if you're sure that the files are owned by the correct user. 
Nexus will fail to start or behave problematically if it can't access the files on the filesystem.

`NEXUS_DATA_CHOWN` is set to `true` by default. 

To disable it, set the environment variable to something else than `true`.