### PR TITLE
Update to Nexus OSS 3.25.1-04, Alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 LABEL maintainer devops@travelaudience.com
 
@@ -6,7 +6,7 @@ LABEL maintainer devops@travelaudience.com
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
 # nexus
-ENV NEXUS_VERSION "3.24.0-02"
+ENV NEXUS_VERSION "3.25.0-03"
 ENV NEXUS_DOWNLOAD_URL "https://download.sonatype.com/nexus/3"
 ENV NEXUS_TARBALL_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz"
 ENV NEXUS_TARBALL_ASC_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz.asc"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer devops@travelaudience.com
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
 # nexus
-ENV NEXUS_VERSION "3.25.0-03"
+ENV NEXUS_VERSION "3.25.1-04"
 ENV NEXUS_DOWNLOAD_URL "https://download.sonatype.com/nexus/3"
 ENV NEXUS_TARBALL_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz"
 ENV NEXUS_TARBALL_ASC_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz.asc"

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A container image for Sonatype Nexus Repository Manager OSS, based on Alpine Lin
 
 * Alpine Linux 3.12
 * OpenJDK JRE 8u212
-* Nexus Repository Manager OSS 3.25.0 ([release notes](https://help.sonatype.com/repomanager3/release-notes/2020-release-notes#id-2020ReleaseNotes-RepositoryManager3.23.0))
+* Nexus Repository Manager OSS 3.25.1 ([release notes](https://help.sonatype.com/repomanager3/release-notes#ReleaseNotes-NexusRepositoryManager3.25.1))
 
 ## Running
 
 Running it locally (for the latest tag, check [quay.io/repository/travelaudience/docker-nexus](https://quay.io/repository/travelaudience/docker-nexus?tab=tags):
 
 ```
-docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.25.0
+docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.25.1
 ```
 
 ## Reasoning


### PR DESCRIPTION
This PR updates the base image to `alpine:3.12` and installs the latest Nexus OSS release `3.25.0-03`.

Please feel free to close/reject this PR, if you don't see fit in your organization. :)