### PR TITLE
Update to 3.29.1-01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 # https://help.sonatype.com/repomanager3/download/download-archives---repository-manager-3
 
 # nexus
-ENV NEXUS_VERSION "3.27.0-03"
+ENV NEXUS_VERSION "3.29.1-01"
 ENV NEXUS_DOWNLOAD_URL "https://download.sonatype.com/nexus/3"
 ENV NEXUS_TARBALL_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz"
 ENV NEXUS_TARBALL_ASC_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz.asc"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A container image for Sonatype Nexus Repository Manager OSS, based on Alpine Lin
 
 * Alpine Linux 3.12
 * OpenJDK JRE 8u212
-* Nexus Repository Manager OSS 3.27.0 ([release notes](https://help.sonatype.com/repomanager3/release-notes#ReleaseNotes-NexusRepositoryManager3.27.0))
+* Nexus Repository Manager OSS 3.29.1 ([release notes](https://help.sonatype.com/repomanager3/release-notes#ReleaseNotes-NexusRepositoryManager3.29.1))
 
 
 ## Running
@@ -15,7 +15,7 @@ A container image for Sonatype Nexus Repository Manager OSS, based on Alpine Lin
 Running it locally (for the latest tag, check [quay.io/repository/travelaudience/docker-nexus](https://quay.io/repository/travelaudience/docker-nexus?tab=tags):
 
 ```
-docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.27.0
+docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.29.1
 ```
 
 ## Reasoning


### PR DESCRIPTION
Update to laste Nexus version 3.29.1-01 as the previous docker images are vulnerable to [CVE-2020-29436](https://support.sonatype.com/hc/en-us/articles/1500000415082-CVE-2020-29436-Nexus-Repository-Manager-3-XML-External-Entities-injection-2020-12-15).



