### PR TITLE
Bump nexus to 3.37.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 # https://help.sonatype.com/repomanager3/download/download-archives---repository-manager-3
 
 # nexus
-ENV NEXUS_VERSION "3.36.0-01"
+ENV NEXUS_VERSION "3.37.0-01"
 ENV NEXUS_DOWNLOAD_URL "https://download.sonatype.com/nexus/3"
 ENV NEXUS_TARBALL_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz"
 ENV NEXUS_TARBALL_ASC_URL "${NEXUS_DOWNLOAD_URL}/nexus-${NEXUS_VERSION}-unix.tar.gz.asc"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ A container image for Sonatype Nexus Repository Manager OSS, based on Alpine Lin
 
 * Alpine Linux 3.14
 * OpenJDK JRE 8u212
-* Nexus Repository Manager OSS 3.36.0 ([release notes](https://help.sonatype.com/repomanager3/release-notes/2021-release-notes/nexus-repository-3.36.0-release-notes))
+* Nexus Repository Manager OSS 3.37.0 ([release notes](https://help.sonatype.com/repomanager3/product-information/release-notes/2021-release-notes/nexus-repository-3.37.0-release-notes))
 
 ## Running
 
 Running it locally (for the latest tag, check [quay.io/repository/travelaudience/docker-nexus](https://quay.io/repository/travelaudience/docker-nexus?tab=tags):
 
 ```shell
-docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.36.0
+docker run -p 8081:8081 --name nexus quay.io/travelaudience/docker-nexus:3.37.0-01
 ```
 
 ## Reasoning


### PR DESCRIPTION
Bump nexus to 3.37.0
See [release notes of 3.37.0 version](https://help.sonatype.com/repomanager3/product-information/release-notes/2021-release-notes/nexus-repository-3.37.0-release-notes)