### PR TITLE
Fix: Revert alpine version due to missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.16
 
 LABEL maintainer devops@travelaudience.com
 


### PR DESCRIPTION
There is an error when running this image due to Alpine version 3.21 not having runsvdir installed by default. Reverting the alpine version upgrade for now.